### PR TITLE
修正：パスワード変更APIを修正

### DIFF
--- a/src/main/java/com/example/health_app/constant/AppConstraints.java
+++ b/src/main/java/com/example/health_app/constant/AppConstraints.java
@@ -1,0 +1,10 @@
+package com.example.health_app.constant;
+
+/**
+ * 定数クラス
+ */
+public class AppConstraints {
+
+	/** パスワードの最小長 */
+	public static final int PASSWORD_MIN_LENGTH = 6;
+}

--- a/src/main/java/com/example/health_app/constant/AppMessage.java
+++ b/src/main/java/com/example/health_app/constant/AppMessage.java
@@ -19,4 +19,5 @@ public class AppMessage {
 	public static final String USER_NOT_FOUND = "ユーザーが見つかりません";
 	public static final String RECORD_NOT_FOUND = "記録が存在しません";
 	public static final String AUTH_FAILED = "認証に失敗しました";
+	public static final String PASSWORD_TOO_SHORT = "新しいパスワードは%d文字以上である必要があります。";
 }

--- a/src/main/java/com/example/health_app/controller/UserController.java
+++ b/src/main/java/com/example/health_app/controller/UserController.java
@@ -5,6 +5,7 @@ import java.util.Map;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -13,6 +14,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.example.health_app.constant.AppConstraints;
 import com.example.health_app.constant.AppKeys;
 import com.example.health_app.constant.AppMessage;
 import com.example.health_app.entity.User;
@@ -86,14 +88,51 @@ public class UserController {
 	}
 
 	/**
-	 * パスワード変更
+	 * ユーザー用パスワード変更
 	 */
+	@PutMapping("/password")
+	public ResponseEntity<?> changePasswordBySelf(Principal principal, @RequestBody Map<String, String> body) {
+
+		// 入力新パスワード
+		String newPassword = body.get(AppKeys.NEW_PASSWORD);
+
+		// 新パスワードがないまたは、パスワードの文字数が6より小さい場合
+		if (newPassword == null || newPassword.length() < AppConstraints.PASSWORD_MIN_LENGTH) {
+
+			// "新しいパスワードは6文字以上である必要があります。"
+			return ResponseEntity.badRequest()
+					.body(String.format(AppMessage.PASSWORD_TOO_SHORT, AppConstraints.PASSWORD_MIN_LENGTH));
+		}
+
+		// ログイン済みユーザー情報を取得する
+		User user = userService.findByUsernameOrThrow(principal.getName());
+
+		// パスワード変更処理
+		userService.changePassword(user.getId(), newPassword);
+
+		// "パスワードを変更しました"
+		return ResponseEntity.ok(AppMessage.USER_CHANGE_PASSWORD);
+	}
+
+	/**
+	 * 管理者用パスワード変更
+	 */
+	@PreAuthorize("hasRole('ADMIN')")
 	@PutMapping("/{id}/password")
 	public ResponseEntity<?> changePassword(@PathVariable Long id, @RequestBody Map<String, String> body) {
 
 		// 入力パスワードを取得する
 		String newPassword = body.get(AppKeys.NEW_PASSWORD);
 
+		// 新パスワードがないまたは、パスワードの文字数が6より小さい場合
+		if (newPassword == null || newPassword.length() < AppConstraints.PASSWORD_MIN_LENGTH) {
+
+			// "新しいパスワードは6文字以上である必要があります。"
+			return ResponseEntity.badRequest()
+					.body(String.format(AppMessage.PASSWORD_TOO_SHORT, AppConstraints.PASSWORD_MIN_LENGTH));
+		}
+
+		// パスワード変更処理
 		userService.changePassword(id, newPassword);
 
 		// "パスワードを変更しました"


### PR DESCRIPTION
## 概要
管理者用とユーザー用にパスワード変更APIを修正しました

## 実装内容
- UserController クラスを修正
- "/api/users/password" エンドポイントを追加（PUT）
- "/api/users/{id}/password" エンドポイントを修正（PUT）
- AppConstants を作成し、定数クラスを追加

## 関連 Issue
fixed #17 