### PR TITLE
修正：ログイン中ユーザー情報が取得できないバグを修正

### DIFF
--- a/src/main/java/com/example/health_app/config/SecurityConfig.java
+++ b/src/main/java/com/example/health_app/config/SecurityConfig.java
@@ -50,9 +50,8 @@ public class SecurityConfig {
 	 * 認証マネージャーを取得する
 	 */
 	@Bean
-	public AuthenticationManager authenticationManager(
-			AuthenticationConfiguration config) throws Exception {
-
+	public AuthenticationManager authenticationManager(AuthenticationConfiguration config) throws Exception {
+		
 		return config.getAuthenticationManager();
 	}
 

--- a/src/main/java/com/example/health_app/constant/AppKeys.java
+++ b/src/main/java/com/example/health_app/constant/AppKeys.java
@@ -11,7 +11,7 @@ public class AppKeys {
 	}
 
 	public static final String JWT_TOKEN = "token";
-	public static final String EMAIL = "email";
+	public static final String USERNAME = "username";
 	public static final String PASSWORD = "password";
 	public static final String NEW_PASSWORD = "newPassword";
 }

--- a/src/main/java/com/example/health_app/controller/AuthController.java
+++ b/src/main/java/com/example/health_app/controller/AuthController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.example.health_app.constant.AppKeys;
 import com.example.health_app.constant.AppMessage;
+import com.example.health_app.entity.Role;
 import com.example.health_app.entity.User;
 import com.example.health_app.security.JwtUtil;
 import com.example.health_app.service.UserService;
@@ -37,22 +38,24 @@ public class AuthController {
 	}
 
 	/**
-	 * メールアドレスとパスワードでユーザーを認証し、JWTトークンを返却する
+	 * ユーザー名とパスワードでユーザーを認証し、JWTトークンを返却する
 	 */
 	@PostMapping("/login")
 	public ResponseEntity<?> login(@RequestBody Map<String, String> body) {
 
 		try {
 
-			String email = body.get(AppKeys.EMAIL);
+			String username = body.get(AppKeys.USERNAME);
 			String password = body.get(AppKeys.PASSWORD);
 
-			// メールアドレスとパスワードで認証処理
+			// ユーザー名とパスワードで認証処理
 			authenticationManager.authenticate(
-					new UsernamePasswordAuthenticationToken(email, password));
+					new UsernamePasswordAuthenticationToken(username, password));
 
-			User user = userService.findByEmail(email).orElseThrow();
-			String token = jwtUtil.generateToken(user.getUsername());
+			User user = userService.findByUsernameOrThrow(username);
+			
+			Role role = user.getRoles().stream().findFirst().orElse(Role.ROLE_USER);
+			String token = jwtUtil.generateToken(user.getUsername(), role);
 
 			Map<String, String> response = new HashMap<>();
 

--- a/src/main/java/com/example/health_app/controller/UserController.java
+++ b/src/main/java/com/example/health_app/controller/UserController.java
@@ -8,6 +8,7 @@ import java.util.stream.Collectors;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -21,6 +22,7 @@ import com.example.health_app.constant.AppKeys;
 import com.example.health_app.constant.AppMessage;
 import com.example.health_app.dto.UserDto;
 import com.example.health_app.entity.User;
+import com.example.health_app.security.CustomUserDetails;
 import com.example.health_app.service.UserService;
 
 import jakarta.persistence.EntityNotFoundException;
@@ -73,12 +75,12 @@ public class UserController {
 	 * ログイン中ユーザー情報取得
 	 */
 	@GetMapping("/me")
-	public ResponseEntity<?> getMyInfo(Principal principal) {
+	public ResponseEntity<?> getMyInfo(@AuthenticationPrincipal CustomUserDetails userDetails) {
 
 		try {
 
 			// ログイン中のユーザー情報を取得する
-			User user = userService.findByUsernameOrThrow(principal.getName());
+			User user = userService.findByUsernameOrThrow(userDetails.getUsername());
 
 			// DTO化
 			return ResponseEntity.ok(toDto(user));
@@ -88,7 +90,6 @@ public class UserController {
 			// "ユーザーが見つかりません"
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(AppMessage.USER_NOT_FOUND);
 		}
-
 	}
 
 	/**

--- a/src/main/java/com/example/health_app/controller/UserController.java
+++ b/src/main/java/com/example/health_app/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.example.health_app.controller;
 
+import java.security.Principal;
 import java.util.Map;
 
 import org.springframework.http.HttpStatus;
@@ -61,6 +62,27 @@ public class UserController {
 			// "ユーザーが見つかりません"
 			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(AppMessage.USER_NOT_FOUND);
 		}
+	}
+
+	/**
+	 * ログイン中ユーザー名取得
+	 */
+	@GetMapping("/me")
+	public ResponseEntity<?> getMyInfo(Principal principal) {
+
+		try {
+
+			// ログイン中のユーザー名を取得する
+			User user = userService.findByUsernameOrThrow(principal.getName());
+
+			return ResponseEntity.ok(user);
+
+		} catch (EntityNotFoundException e) {
+
+			// "ユーザーが見つかりません"
+			return ResponseEntity.status(HttpStatus.NOT_FOUND).body(AppMessage.USER_NOT_FOUND);
+		}
+
 	}
 
 	/**

--- a/src/main/java/com/example/health_app/entity/User.java
+++ b/src/main/java/com/example/health_app/entity/User.java
@@ -61,9 +61,13 @@ public class User {
 	 */
 	private String gender;
 
+	/**
+	 * ロール
+	 */
 	@ElementCollection(fetch = FetchType.EAGER)
 	@CollectionTable(name = "user_roles", joinColumns = @JoinColumn(name = "user_id"))
 	@Enumerated(EnumType.STRING)
+	@Column(name = "role")
 	private Set<Role> roles = new HashSet<>();
 
 	/**

--- a/src/main/java/com/example/health_app/security/JwtUtil.java
+++ b/src/main/java/com/example/health_app/security/JwtUtil.java
@@ -6,6 +6,7 @@ import java.util.Date;
 import org.springframework.stereotype.Component;
 
 import com.example.health_app.constant.SecurityConstants;
+import com.example.health_app.entity.Role;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.JwtException;
@@ -25,11 +26,12 @@ public class JwtUtil {
 	/**
 	 * JWTを発行する(トークンを生成)
 	 */
-	public String generateToken(String username) {
+	public String generateToken(String username, Role role) {
 
 		// ユーザー名、発行日時、有効期限、署名をJWT文字列に変換し、返却する
 		return Jwts.builder()
 				.setSubject(username) // トークンの対象（ユーザー名)
+				.claim("role", role.name()) // ロール
 				.setIssuedAt(new Date()) // 発行時刻
 				.setExpiration(new Date(System.currentTimeMillis() + SecurityConstants.EXPIRATION_MS)) // 24時間有効
 				.signWith(secretKey, SignatureAlgorithm.HS256) // 署名

--- a/src/main/java/com/example/health_app/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/health_app/security/UserDetailsServiceImpl.java
@@ -23,11 +23,11 @@ public class UserDetailsServiceImpl implements UserDetailsService {
 	}
 
 	@Override
-	public UserDetails loadUserByUsername(String usernameOrEmail) {
-		
-		User user = userRepository.findByEmail(usernameOrEmail)
+	public UserDetails loadUserByUsername(String username) {
+
+		User user = userRepository.findByUsername(username)
 				.orElseThrow(() -> new EntityNotFoundException(AppMessage.USER_NOT_FOUND));
-		
+
 		return new CustomUserDetails(user);
 	}
 }


### PR DESCRIPTION
## 概要
Postmanによる "api/users/me" テスト実行時、403エラーが発生している問題を修正しました。

## 修正内容
- トークン認証に使用していたメールアドレスをユーザー名に変更
- トークン生成時、ロールも文字列へ追加

## 修正後の挙動
→ いずれもユーザー情報を返す

## テスト時ユーザー情報
- username : testuser
- password : test1234

## 関連 Issue
fixed #23 