### PR TITLE
追加：Service層のユニットテストを実装

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,13 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+	            <!-- 古い JUnit4 (Vintage) を除外して JUnit5 に統一 -->
+	            <exclusion>
+	                <groupId>org.junit.vintage</groupId>
+	                <artifactId>junit-vintage-engine</artifactId>
+	            </exclusion>
+        	</exclusions>
 		</dependency>
 		
 		<dependency>

--- a/src/test/java/com/example/health_app/service/AdminServiceTest.java
+++ b/src/test/java/com/example/health_app/service/AdminServiceTest.java
@@ -1,0 +1,94 @@
+package com.example.health_app.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.example.health_app.dto.DashboardDto;
+import com.example.health_app.dto.UserDto;
+import com.example.health_app.entity.Role;
+import com.example.health_app.entity.User;
+import com.example.health_app.repository.HealthRecordRepository;
+import com.example.health_app.repository.UserRepository;
+
+/**
+ * Mockの単体テスト用
+ * ・ADMIN数を集計
+ * ・本日のアクティブユーザーを算出
+ */
+@ExtendWith(MockitoExtension.class)
+class AdminServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock HealthRecordRepository healthRecordRepository;
+
+    @InjectMocks AdminService adminService;
+
+    @Test
+    void getAllUsers_mapsToDto() {
+        // given
+        User u1 = new User();
+        u1.setId(1L); u1.setUsername("alice"); u1.setEmail("alice@example.com");
+        u1.setRoles(Set.of(Role.ROLE_USER));
+
+        User u2 = new User();
+        u2.setId(2L); u2.setUsername("admin"); u2.setEmail("admin@example.com");
+        u2.setRoles(Set.of(Role.ROLE_ADMIN, Role.ROLE_USER));
+
+        when(userRepository.findAll()).thenReturn(List.of(u1, u2));
+
+        // when
+        List<UserDto> dtos = adminService.getAllUsers();
+
+        // then
+        assertEquals(2, dtos.size());
+        var d1 = dtos.get(0);
+        var d2 = dtos.get(1);
+
+        assertEquals(1L, d1.getId());
+        assertEquals("alice", d1.getUsername());
+        assertTrue(d1.getRoles().contains("ROLE_USER"));
+
+        assertEquals(2L, d2.getId());
+        assertEquals("admin", d2.getUsername());
+        assertTrue(d2.getRoles().contains("ROLE_ADMIN"));
+        assertTrue(d2.getRoles().contains("ROLE_USER"));
+
+        verify(userRepository, times(1)).findAll();
+        verifyNoMoreInteractions(userRepository);
+        verifyNoInteractions(healthRecordRepository);
+    }
+
+    @Test
+    void getDashboardData_aggregatesCounts() {
+        // totalUsers / totalRecords
+        when(userRepository.count()).thenReturn(10L);
+        when(healthRecordRepository.count()).thenReturn(123L);
+
+        when(userRepository.countByRole(Role.ROLE_ADMIN)).thenReturn(1L);
+        when(healthRecordRepository.countDistinctUsersByRecordDate(any(LocalDate.class))).thenReturn(2L);
+
+        DashboardDto dto = adminService.getDashboardData();
+
+        assertEquals(10L, dto.getTotalUsers());
+        assertEquals(1L, dto.getAdminUsers());
+        assertEquals(123L, dto.getTotalRecords());
+        assertEquals(2L, dto.getTodayActiveUsers());
+
+        verify(userRepository).count();
+        verify(healthRecordRepository).count();
+        verify(userRepository).countByRole(Role.ROLE_ADMIN);
+        verify(healthRecordRepository).countDistinctUsersByRecordDate(any(LocalDate.class));
+        verifyNoMoreInteractions(userRepository, healthRecordRepository);
+    }
+}

--- a/src/test/java/com/example/health_app/service/HealthRecordServiceTest.java
+++ b/src/test/java/com/example/health_app/service/HealthRecordServiceTest.java
@@ -1,0 +1,137 @@
+package com.example.health_app.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.access.AccessDeniedException;
+
+import com.example.health_app.dto.HealthRecordRequestDto;
+import com.example.health_app.entity.HealthRecord;
+import com.example.health_app.entity.Role;
+import com.example.health_app.entity.User;
+import com.example.health_app.repository.HealthRecordRepository;
+import com.example.health_app.repository.UserRepository;
+
+import jakarta.persistence.EntityNotFoundException;
+
+/**
+ * Mockの単体テスト用
+ * ・記録作成（成功・ユーザー無し）
+ * ・記録取得
+ * ・削除（成功・権限無し）
+ */
+@ExtendWith(MockitoExtension.class)
+class HealthRecordServiceTest {
+
+	@Mock
+	HealthRecordRepository recordRepository;
+	@Mock
+	UserRepository userRepository;
+
+	@InjectMocks
+	HealthRecordService service;
+
+	@Test
+	void createRecord_success() {
+		User user = new User();
+		user.setId(10L);
+		when(userRepository.findById(10L)).thenReturn(Optional.of(user));
+		when(recordRepository.save(any(HealthRecord.class)))
+				.thenAnswer(inv -> inv.getArgument(0));
+
+		HealthRecordRequestDto dto = new HealthRecordRequestDto();
+		dto.setRecordDate(LocalDate.now());
+		dto.setWeight(70.0);
+
+		HealthRecord saved = service.createRecord(10L, dto);
+
+		assertEquals(user, saved.getUser());
+		assertEquals(70.0, saved.getWeight());
+	}
+
+	@Test
+    void createRecord_userNotFound_throws() {
+        when(userRepository.findById(99L)).thenReturn(Optional.empty());
+        assertThrows(EntityNotFoundException.class,
+                () -> service.createRecord(99L, new HealthRecordRequestDto()));
+    }
+
+	@Test
+	void getRecordsByUserId_returnsList() {
+		HealthRecord rec = new HealthRecord();
+		rec.setId(1L);
+		when(recordRepository.findByUserIdOrderByRecordDateDesc(10L))
+				.thenReturn(List.of(rec));
+
+		List<HealthRecord> list = service.getRecordsByUserId(10L);
+
+		assertEquals(1, list.size());
+		assertEquals(1L, list.get(0).getId());
+	}
+
+	@Test
+	void deleteRecordAs_owner_canDelete() {
+		User owner = new User();
+		owner.setId(1L);
+		owner.setRoles(Set.of(Role.ROLE_USER));
+
+		HealthRecord rec = new HealthRecord();
+		rec.setId(100L);
+		rec.setUser(owner);
+
+		when(recordRepository.findById(100L)).thenReturn(Optional.of(rec));
+
+		assertDoesNotThrow(() -> service.deleteRecordAs(100L, owner));
+		verify(recordRepository).delete(rec);
+	}
+
+	@Test
+	void deleteRecordAs_admin_canDelete() {
+		User admin = new User();
+		admin.setId(2L);
+		admin.setRoles(Set.of(Role.ROLE_ADMIN));
+
+		User other = new User();
+		other.setId(3L);
+
+		HealthRecord rec = new HealthRecord();
+		rec.setId(200L);
+		rec.setUser(other);
+
+		when(recordRepository.findById(200L)).thenReturn(Optional.of(rec));
+
+		assertDoesNotThrow(() -> service.deleteRecordAs(200L, admin));
+		verify(recordRepository).delete(rec);
+	}
+
+	@Test
+	void deleteRecordAs_notOwner_notAdmin_denied() {
+		User requester = new User();
+		requester.setId(5L);
+		requester.setRoles(Set.of(Role.ROLE_USER));
+
+		User owner = new User();
+		owner.setId(1L);
+
+		HealthRecord rec = new HealthRecord();
+		rec.setId(300L);
+		rec.setUser(owner);
+
+		when(recordRepository.findById(300L)).thenReturn(Optional.of(rec));
+
+		assertThrows(AccessDeniedException.class,
+				() -> service.deleteRecordAs(300L, requester));
+		verify(recordRepository, never()).delete(any());
+	}
+}

--- a/src/test/java/com/example/health_app/service/UserServiceTest.java
+++ b/src/test/java/com/example/health_app/service/UserServiceTest.java
@@ -1,0 +1,92 @@
+package com.example.health_app.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import com.example.health_app.constant.AppMessage;
+import com.example.health_app.entity.Role;
+import com.example.health_app.entity.User;
+import com.example.health_app.repository.UserRepository;
+
+/**
+ * Mockの単体テスト用
+ * ・ユーザー登録（成功・失敗）
+ * ・パスワード変更
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+	@Mock UserRepository userRepository;
+    @Mock PasswordEncoder passwordEncoder;
+
+    @InjectMocks UserService userService;
+
+    User newUser;
+
+    @BeforeEach
+    void setup() {
+        newUser = new User();
+        newUser.setUsername("testuser");
+        newUser.setEmail("test@example.com");
+        newUser.setPassword("plainpass");
+    }
+
+    @Test
+    void registerUser_success() {
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode("plainpass")).thenReturn("hashedpass");
+
+        when(userRepository.save(any(User.class))).thenAnswer(inv -> {
+            User u = inv.getArgument(0);
+            u.setId(1L);
+            return u;
+        });
+
+        User saved = userService.registerUser(newUser);
+
+        assertNotNull(saved.getId());
+        assertEquals("hashedpass", saved.getPassword());
+        assertTrue(saved.getRoles().contains(Role.ROLE_USER));
+    }
+
+    @Test
+    void registerUser_duplicateEmail_throws() {
+        when(userRepository.findByUsername("testuser")).thenReturn(Optional.of(new User()));
+
+        IllegalArgumentException ex =
+                assertThrows(IllegalArgumentException.class, () -> userService.registerUser(newUser));
+        assertEquals(AppMessage.USERNAME_ALREADY_USED, ex.getMessage());
+    }
+
+    @Test
+    void changePassword_success() {
+        User user = new User();
+        user.setId(99L);
+        user.setPassword("oldpass");
+
+        when(userRepository.findById(99L)).thenReturn(Optional.of(user));
+        when(passwordEncoder.encode("newpass")).thenReturn("hashedNew");
+
+        userService.changePassword(99L, "newpass");
+
+        assertEquals("hashedNew", user.getPassword());
+        verify(userRepository).save(user);
+    }
+
+    @Test
+    void changePassword_userNotFound_throws() {
+        when(userRepository.findById(123L)).thenReturn(Optional.empty());
+
+        assertThrows(RuntimeException.class, () -> userService.changePassword(123L, "x"));
+    }
+}


### PR DESCRIPTION
## 概要
JUnit5 と Mockito を用いて、Service層のユニットテストを実施しました。

## 実装内容
- AdminServiceTest、HealthRecordServiceTest、UserServiceTestクラスを追加
- JUnit5 と Mockito を使用

## 実施結果
- エラー無くテスト完了

## 関連issue
- fixes #27 